### PR TITLE
do not load all files into memory at once

### DIFF
--- a/lib/bitballoon/site.rb
+++ b/lib/bitballoon/site.rb
@@ -11,7 +11,9 @@ module BitBalloon
       return unless state == "uploading"
 
       shas = Hash.new { [] }
-      Dir[::File.join(dir, "**", "*")].each do |file|
+      glob = ::File.join(dir, "**", "*")
+      
+      Dir.glob(glob) do |file|
         next unless ::File.file?(file)
         pathname = ::File.join("/", file[dir.length..-1])
         next if pathname.match(/(^\/?__MACOSX\/|\/\.)/)


### PR DESCRIPTION
Dir[...] should _never_ be used in real code as it loads everything into memory at once.  the block form of Dir.glob(&block) loads one at the time.
