### PR TITLE
Upgrade oauth2 to current version.

### DIFF
--- a/bitballoon.gemspec
+++ b/bitballoon.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "oauth2", "~>  0.9.2"
+  gem.add_dependency "oauth2", "~>  1.1.0"
   gem.add_dependency "slop", "~> 3.6.0"
   gem.add_dependency "highline", "~> 1.6.21"
   gem.add_development_dependency "minitest"


### PR DESCRIPTION
The 0.9.x version of oauth2 still rely on the default SSL settings. As a result, it attempts to connect to the authorization server using SSLv3. It appears that your authorization server no longer support that protocol (which is a good thing due to :poodle:).

Your tests are still passing after upgrading oauth2 to 1.1.0. This should address #13 .
